### PR TITLE
Finish migration from KV to D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ When registering new commands or updating existing commands, run this on the com
 ### Run locally
 
 To deploy to cloudflare, copy the `wrangler.toml.example` and rename it to
-`wrangler.toml`. Fill in the blanks with the correct information. You'll need your cloudflare account id,
-keyspace id, and preview keyspace id.
+`wrangler.toml`. Fill in the blanks with the correct information. You'll need your cloudflare account id
+and your D1 database ids for each environment.
 
 To run locally, start up the cloudflare worker locally: `npm run dev`
 

--- a/src/managers/messageManager.js
+++ b/src/managers/messageManager.js
@@ -10,14 +10,6 @@ export const createInitialLfgMessage = async (message, env) => {
   let startTime = getStartTimeFromMessage(message);
   let lookingForGroupMessage = createLookingForGroupMessage(message, startTime);
 
-  await env.LFG.put(
-    message.id,
-    JSON.stringify({
-      joinedUsers: [],
-      originalMessage: lookingForGroupMessage,
-    })
-  );
-
   let startTimeToBind = startTime !== undefined ? startTime : null;
 
   await env.DB.prepare(
@@ -164,11 +156,29 @@ export const joinLfgMessage = async (message, env, joinedGroup) => {
   const userId = message.member.user.id;
   const interactionId = message.message.interaction.id;
 
-  //TODO once the new D1 database has been running for a few days, swap this out to an sql call.
-  const currentActiveMessage = JSON.parse(await env.LFG.get(interactionId));
+  const joinedUsersResults = await env.DB.prepare(
+    "SELECT userId FROM JoinedUsers WHERE messageId = ?1 ORDER BY joinedAt ASC"
+  )
+    .bind(interactionId.toString())
+    .all();
 
-  if (!currentActiveMessage.joinedUsers.includes(userId) && joinedGroup) {
-    currentActiveMessage.joinedUsers.push(userId);
+  let joinedUsers = joinedUsersResults?.results?.map((row) => row.userId) || [];
+
+  const lookingForGroupMessage = await env.DB.prepare(
+    "SELECT content FROM LookingForGroupMessages WHERE messageId = ?1"
+  )
+    .bind(interactionId.toString())
+    .first();
+
+  if (!lookingForGroupMessage) {
+    return new JsonResponse(
+      { error: "Unable to find original looking for group message" },
+      { status: 404 }
+    );
+  }
+
+  if (!joinedUsers.includes(userId) && joinedGroup) {
+    joinedUsers.push(userId);
     await env.DB.prepare(
       "INSERT INTO JoinedUsers(userId, messageId, joinedAt)" +
         "VALUES (?1, ?2, ?3) " +
@@ -177,11 +187,7 @@ export const joinLfgMessage = async (message, env, joinedGroup) => {
       .bind(userId.toString(), interactionId.toString(), Date.now())
       .run();
   } else if (!joinedGroup) {
-    currentActiveMessage.joinedUsers = currentActiveMessage.joinedUsers.filter(
-      (id) => {
-        return id !== userId;
-      }
-    );
+    joinedUsers = joinedUsers.filter((id) => id !== userId);
     await env.DB.prepare(
       "DELETE FROM JoinedUsers WHERE userId = ?1 AND messageId = ?2"
     )
@@ -189,11 +195,9 @@ export const joinLfgMessage = async (message, env, joinedGroup) => {
       .run();
   }
 
-  await env.LFG.put(interactionId, JSON.stringify(currentActiveMessage));
-
-  const joinedMessaged = `${
-    currentActiveMessage.originalMessage
-  } ${getCurrentActiveJoinedList(currentActiveMessage.joinedUsers)}`;
+  const joinedMessaged = `${lookingForGroupMessage.content} ${getCurrentActiveJoinedList(
+    joinedUsers
+  )}`;
 
   try {
     return new JsonResponse({

--- a/src/managers/messageManager.js
+++ b/src/managers/messageManager.js
@@ -154,12 +154,12 @@ function getStartTimeFromMessage(message) {
 
 export const joinLfgMessage = async (message, env, joinedGroup) => {
   const userId = message.member.user.id;
-  const interactionId = message.message.interaction.id;
+  const messageId = message.message.interaction.id;
 
   const joinedUsersResults = await env.DB.prepare(
     "SELECT userId FROM JoinedUsers WHERE messageId = ?1 ORDER BY joinedAt ASC"
   )
-    .bind(interactionId.toString())
+    .bind(messageId.toString())
     .all();
 
   let joinedUsers = joinedUsersResults?.results?.map((row) => row.userId) || [];
@@ -167,7 +167,7 @@ export const joinLfgMessage = async (message, env, joinedGroup) => {
   const lookingForGroupMessage = await env.DB.prepare(
     "SELECT content FROM LookingForGroupMessages WHERE messageId = ?1"
   )
-    .bind(interactionId.toString())
+    .bind(messageId.toString())
     .first();
 
   if (!lookingForGroupMessage) {
@@ -184,14 +184,14 @@ export const joinLfgMessage = async (message, env, joinedGroup) => {
         "VALUES (?1, ?2, ?3) " +
         "ON CONFLICT(userId, messageId) DO NOTHING;"
     )
-      .bind(userId.toString(), interactionId.toString(), Date.now())
+      .bind(userId.toString(), messageId.toString(), Date.now())
       .run();
   } else if (!joinedGroup) {
     joinedUsers = joinedUsers.filter((id) => id !== userId);
     await env.DB.prepare(
       "DELETE FROM JoinedUsers WHERE userId = ?1 AND messageId = ?2"
     )
-      .bind(userId.toString(), interactionId.toString())
+      .bind(userId.toString(), messageId.toString())
       .run();
   }
 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -10,18 +10,12 @@ type = "ESModule"
 globs = [ "**/*.js" ]
 
 [env.dev]
-kv_namespaces = [
-    { binding = "LFG", id="<DEV_KV_ID>" }
-]
 d1_databases = [
     { binding = "DB", database_name="<DEV_DATABASE_NAME>", database_id="<DEV_UUID>", remote = true}
 ]
 vars = { DISCORD_TOKEN = "<DISCORD_TOKEN>", DISCORD_PUBLIC_KEY = "<DISCORD_PUBLIC_KEY>", DISCORD_APPLICATION_ID = "<DISCORD_APPLICATION_ID>" }
 
 [env.production]
-kv_namespaces = [
-    { binding = "LFG", id = "<PROD_KV_ID>" }
-]
 d1_databases = [
     { binding = "DB", database_name="<PROD_DATABASE_NAME>", database_id="<PROD_UUID>"}
 ]


### PR DESCRIPTION
## Summary
- remove Cloudflare KV usage for looking for group data and persist through D1 tables instead
- read original messages and joined users from the D1 database when updating interaction responses
- clean up configuration and docs to reflect the move away from KV bindings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692376329e708325a30d7152468ee9e2)